### PR TITLE
"foreground" typo fix

### DIFF
--- a/cordova/plugin/LocalNotification.m
+++ b/cordova/plugin/LocalNotification.m
@@ -42,7 +42,7 @@
     notif.soundName = sound;
     notif.applicationIconBadgeNumber = badge;
 	
-	NSDictionary *userDict = [NSDictionary dictionaryWithObjectsAndKeys:notificationId,@"notificationId",bg,@"background",fg,@"forground",nil];
+	NSDictionary *userDict = [NSDictionary dictionaryWithObjectsAndKeys:notificationId,@"notificationId",bg,@"background",fg,@"foreground",nil];
     
     notif.userInfo = userDict;
 	

--- a/phonegap/project/localNotifications/LocalNotification.m
+++ b/phonegap/project/localNotifications/LocalNotification.m
@@ -42,7 +42,7 @@
     notif.soundName = sound;
     notif.applicationIconBadgeNumber = badge;
 	
-	NSDictionary *userDict = [NSDictionary dictionaryWithObjectsAndKeys:notificationId,@"notificationId",bg,@"background",fg,@"forground",nil];
+	NSDictionary *userDict = [NSDictionary dictionaryWithObjectsAndKeys:notificationId,@"notificationId",bg,@"background",fg,@"foreground",nil];
     
     notif.userInfo = userDict;
 	


### PR DESCRIPTION
This fixes a dictionary misspelling that I got snagged on.
