### PR TITLE
Fixed issue that caused the app to crash when canceling a notification

### DIFF
--- a/cordova/plugin/LocalNotification.m
+++ b/cordova/plugin/LocalNotification.m
@@ -52,7 +52,7 @@
 }
 
 - (void)cancelNotification:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
-	NSString *notificationId = [arguments objectAtIndex:0];
+        NSString *notificationId = [NSString stringWithFormat:@"%@",[arguments objectAtIndex:0]];
 	NSArray *notifications = [[UIApplication sharedApplication] scheduledLocalNotifications];
 	for (UILocalNotification *notification in notifications) {
 		NSString *notId = [notification.userInfo objectForKey:@"notificationId"];


### PR DESCRIPTION
This is a fix for [issue number 8](https://github.com/DrewDahlman/Phonegap-LocalNotification/issues/8). The issue is related to integer to string conversion when canceling a notification. 
